### PR TITLE
MCP-Transcribe server 

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ If you have any disconnect issue check the `manifest.json` at these useful repos
 
 ### Productivity
 
+- [transcribe-app/mcp-transcribe](https://github.com/transcribe-app/mcp-transcribe) - This service provides fast and reliable transcriptions for audio/video files and voice memos. It allows LLMs to interact with the text content of audio/video files.
 - [Fibery-inc/fibery-mcp-server](https://github.com/Fibery-inc/fibery-mcp-server) - This MCP (Model Context Protocol) server provides integration between Fibery and any LLM provider supporting the MCP protocol (e.g., Claude for Desktop), allowing you to interact with your Fibery workspace using natural language.
 - [ivo-toby/contentful-mcp](https://github.com/ivo-toby/contentful-mcp) - Read, update, delete, publish content in your [Contentful](https://contentful.com/) space(s) from this MCP Server.
 - [jerhadf/linear-mcp-server](https://github.com/jerhadf/linear-mcp-server) - Allows LLM to interact with Linear's API for project management, including searching, creating, and updating issues.

--- a/servers/Transcribe-app/MCP-Transcribe/manifest.json
+++ b/servers/Transcribe-app/MCP-Transcribe/manifest.json
@@ -1,0 +1,64 @@
+{
+  "version": "1.0.2",
+  "dxt_version": "0.1",
+  "name": "Transcribe.com tools",
+  "description": "Essential tools for transcribing audio and video files and converting audio into text",
+  "author": {
+    "name": "Transcribe.com",
+    "email": "support@transcribe.com",
+    "url": "https://github.com/transcribe-app/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/transcribe-app/mcp-transcribe"
+  },
+  "homepage": "https://transcribe.com",
+  "icon": "favicon-32x32.png",
+  "server": {
+    "type": "node",
+    "entry_point": "build/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/build/index.js"
+      ],
+      "env": {
+        "MCP_INTEGRATION_URL": "${user_config.MCP_INTEGRATION_URL}"
+      }
+    }
+  },
+  "compatibility": {
+    "runtimes": {
+      "node": ">=20.0.0"
+    }
+  },
+  "tools": [
+    {
+      "name": "transcribe-file-convert-to-text"
+    }
+  ],
+  "user_config": {
+    "MCP_INTEGRATION_URL": {
+      "type": "string",
+      "title": "MCP Integration URL",
+      "description": "MCP Integration URL from your account at https://transcribe.com, can be found in Automation popup",
+      "required": true,
+      "sensitive": true
+    }
+  },
+  "keywords": [
+    "transcription",
+    "dictation",
+    "otter",
+    "meeting",
+    "notes",
+    "live",
+    "convert",
+    "interview",
+    "classes",
+    "research",
+    "irecord",
+    "service"
+  ],
+  "license": "MIT"
+}

--- a/servers/Transcribe-app/MCP-Transcribe/user_config.json
+++ b/servers/Transcribe-app/MCP-Transcribe/user_config.json
@@ -1,0 +1,9 @@
+{
+    "MCP_INTEGRATION_URL": {
+      "type": "string",
+      "title": "MCP Integration URL",
+      "description": "MCP Integration URL from your account at https://transcribe.com, can be found in Automation popup",
+      "required": true,
+      "sensitive": true
+    }
+  }


### PR DESCRIPTION
MCP-Transcribe server allows LLMs to interact with the text content of audio/video files.
Available both as Local (DXT) installation and as Remote service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new module for transcribing audio and video files into text, including essential tools and user configuration options.
* **Documentation**
  * Added a new entry in the README under "Productivity" highlighting the transcribe-app/mcp-transcribe repository and its capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->