### PR TITLE
Add MichaelAdamGroberman/mac-mcp under System Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ If you have any disconnect issue check the `manifest.json` at these useful repos
 - [ChristophEnglisch/keycloak-model-context-protocol](https://github.com/ChristophEnglisch/keycloak-model-context-protocol) - This MCP server enables natural language interaction with Keycloak for user and realm management including creating, deleting, and listing users and realms.
 - [modelcontextprotocol/filesystem](https://github.com/modelcontextprotocol/servers/blob/main/src/filesystem) - Secure file operations with configurable access controls
 - [Descope/descope-mcp-server](https://github.com/descope-sample-apps/descope-mcp-server) - An MCP server to integrate with [Descope](https://descope.com/) to search audit logs, manage users, and more.
+- [MichaelAdamGroberman/mac-mcp](https://github.com/MichaelAdamGroberman/mac-mcp) - Native macOS control via Swift + AppKit + Accessibility + cached OSAKit. 32 typed allow-listed tools across windows, Finder, clipboard, screenshots, mouse/trackpad/keyboard (CGEvent), Mail/Calendar/Messages/Safari/Notes, iTerm/Terminal, and iPhone Mirroring. Code-signed Developer ID + hardened runtime for stable TCC grants. No `run_shell` / `run_applescript` escape hatches. Ships as a one-click `.mcpb`.
 
 ### Web Services
 


### PR DESCRIPTION
## Summary

Adds [`MichaelAdamGroberman/mac-mcp`](https://github.com/MichaelAdamGroberman/mac-mcp) to the **System Tools** section.

## What it is

A native macOS control extension packaged as a one-click `.mcpb` (formerly `.dxt`). 32 typed allow-listed tools across:

- Window/app management (Accessibility API)
- Finder ops (selection, tags, Spotlight, Quick Look, trash)
- System (typed clipboard, notifications, native input dialogs, screenshots)
- Mouse/trackpad/keyboard (CGEvent — bounded coordinates, capped drag distance, capped type length)
- Per-app automation: Mail, Calendar, Messages, Safari, Notes
- iTerm2 + Terminal.app
- iPhone Mirroring (Sonoma+)

## Why it might be useful for the list

- **Native APIs over shell-out:** AppKit, AXUIElement, NSPasteboard, UNUserNotificationCenter, CGWindowList, CGEvent, and pre-compiled OSAKit (no `osascript -e` round-trips).
- **Code-signed Developer ID + hardened runtime + stapled (in-flight)** so TCC grants persist across rebuilds (one Accessibility/Automation prompt, then quiet).
- **No escape hatches:** no `run_shell`, `run_applescript`, or `eval_*` tools by design.
- **Local-only:** zero outbound network (`NSAllowsArbitraryLoads=false`, empty `NSPinnedDomains`); audit log is local JSONL.

## Repo

- License: MIT
- Latest release: [v0.1.0](https://github.com/MichaelAdamGroberman/mac-mcp/releases/tag/v0.1.0) — includes the signed `mac-mcp.mcpb` asset
- Topics: `mcp`, `mcpb`, `dxt`, `claude-desktop`, `macos`, `swift`, `accessibility`, `applescript`, `automation`, `iphone-mirroring`

Happy to adjust placement / description if a different section fits better.