### PR TITLE
Add namemyapp under Web Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ If you have any disconnect issue check the `manifest.json` at these useful repos
 - [modelcontextprotocol/fetch](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) - A Model Context Protocol server that provides web content fetching capabilities.
 
 - [Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data MCP server & AI agent skill. REST API and 20 extraction tools for profiles, tweets, followers, and more.
-- [Rakesh1002/namemyapp](https://github.com/Rakesh1002/namemyapp) - Generate brandable business names with live domain availability and one-click buy URLs. 12 tools: AI naming, domain check, registration, DNS, logos, legal docs, brand & social kits. Remote MCP at `https://mcp.namemy.app/mcp` (OAuth) and `/direct` (bearer); npm: `@namemyapp/mcp`.
+- [Rakesh1002/namemyapp-mcp](https://github.com/Rakesh1002/namemyapp-mcp) - Generate brandable business names with live domain availability and one-click buy URLs. 12 tools: AI naming, domain check, registration, DNS, logos, legal docs, brand & social kits. Remote MCP at `https://mcp.namemy.app/mcp` (OAuth) and `/direct` (bearer); npm: `@namemyapp/mcp`.
 
 ### Messaging
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ If you have any disconnect issue check the `manifest.json` at these useful repos
 - [modelcontextprotocol/fetch](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) - A Model Context Protocol server that provides web content fetching capabilities.
 
 - [Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data MCP server & AI agent skill. REST API and 20 extraction tools for profiles, tweets, followers, and more.
+- [Rakesh1002/namemyapp](https://github.com/Rakesh1002/namemyapp) - Generate brandable business names with live domain availability and one-click buy URLs. 12 tools: AI naming, domain check, registration, DNS, logos, legal docs, brand & social kits. Remote MCP at `https://mcp.namemy.app/mcp` (OAuth) and `/direct` (bearer); npm: `@namemyapp/mcp`.
 
 ### Messaging
 


### PR DESCRIPTION
## What

Adds [namemyapp-mcp](https://github.com/Rakesh1002/namemyapp-mcp) to the **Web Services** category.

## About

namemy.app generates brandable business names fused with **live domain availability** so every suggestion is purchasable, then drives the user to a one-click buy URL.

- **12 tools** exposed via MCP — AI name generation, domain availability check (no API key), domain registration, DNS management, brand-conflict (USPTO), logo generation, legal doc generation, brand kits, social media kits.
- **Public tools** (`buy_link`, `check_domain_public`) work with no API key. The other 10 require a free API key.
- **Remote MCP server** is live: `https://mcp.namemy.app/mcp` (OAuth 2.1 PKCE) and `https://mcp.namemy.app/direct` (bearer-token).
- **stdio**: `npx -y @namemyapp/mcp` (latest **1.1.6**)
- **Source**: https://github.com/Rakesh1002/namemyapp-mcp (MIT)
- **Docs**: https://namemy.app/agents
- **Official MCP Registry**: `io.github.Rakesh1002/namemyapp@1.1.5`

## Checklist

- [x] Entry includes a short description
- [x] Tested the link
- [x] Did not break formatting