### PR TITLE
Add tdmcp — TouchDesigner MCP server (Media Creation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ If you have any disconnect issue check the `manifest.json` at these useful repos
 - [dschuler36/reaper-mcp-server](https://github.com/dschuler36/reaper-mcp-server) - Interact with your [Reaper](https://www.reaper.fm/) (Digital Audio Workstation) projects.
 - [quazaai/UnityMCPIntegration](https://github.com/quazaai/UnityMCPIntegration) - Advanced Unity3d Game Engine MCP which supports ,Execution of Any Editor Related Code Directly Inside of Unity, Fetch Logs, Get Editor State and Allow File Access of the Project making it much more useful in Script Editing or asset creation.
 - [Coding Solo/godot-mcp](https://github.com/Coding-Solo/godot-mcp) - A MCP server providing comprehensive Godot engine integration for project editing, debugging, and scene management.
+- [Pantani/tdmcp](https://github.com/Pantani/tdmcp) - Build real TouchDesigner node networks from plain language (audio-reactive visuals, feedback loops, particles, generative art, projection mapping) with a create→verify→preview loop. Ships a one-click .dxt for Claude Desktop.
 
 ### Productivity
 


### PR DESCRIPTION
Adds **tdmcp** (TouchDesigner MCP server) under **Media Creation**.

tdmcp builds real, wired TouchDesigner node networks from plain language — audio-reactive visuals, feedback loops, particles, generative art, projection mapping — with a create→verify→preview loop. It ships a one-click `.dxt` for Claude Desktop, and is also on npm (`@dpantani/tdmcp`) and the official MCP registry (`io.github.Pantani/tdmcp`).

- Repo: https://github.com/Pantani/tdmcp
- Install path is `npx` (`npx -y @dpantani/tdmcp`), matching the Quick Contribution guideline for npx/uvx servers.
- One entry added under the Media Creation category; no other changes.