### PR TITLE
Add TWZRD Agent Intel to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ If you have any disconnect issue check the `manifest.json` at these useful repos
 - [mcpdotdirect/evm-mcp-server](https://github.com/mcpdotdirect/evm-mcp-server) - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - [marctheshark3/ergo-mcp](https://github.com/marctheshark3/ergo-mcp) - -An MCP server to integrate Ergo Blockchain Node and Explorer APIs for checking address balances, analyzing transactions, viewing transaction history, performing forensic analysis of addresses, searching for tokens, and monitoring network status.
 - [XeroAPI/xero-mcp-server](https://github.com/XeroAPI/xero-mcp-server) - This is a Model Context Protocol (MCP) server implementation for Xero. It provides a bridge between the MCP protocol and Xero's API, allowing for standardized access to Xero's accounting and business features.
+- [twzrd-sol/twzrd-agent-intel](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel) - Solana agent trust scoring via x402 micropayments — free on-chain preflight checks + paid signed V5 trust receipts settled in <1s via remote MCP at intel.twzrd.xyz.
 
 ### examples
 


### PR DESCRIPTION
## Summary

- Adds **TWZRD Agent Intel** to the `### Finance` section
- Solana-native agent trust scoring via x402 micropayments
- Free on-chain preflight checks + paid signed V5 trust receipts settled in <1s
- Remote MCP server hosted at `intel.twzrd.xyz/mcp`
- Repo: https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel

🤖 Generated with [Claude Code](https://claude.com/claude-code)