### PR TITLE
feat: add NotFair — SEO, Google Ads & Meta Ads agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ If you have any disconnect issue check the `manifest.json` at these useful repos
 - [abhiz123/todoist-mcp-server](https://github.com/abhiz123/todoist-mcp-server) - Interact with Todoist to manage your tasks.
 - [sooperset/mcp-atlassian](https://github.com/sooperset/mcp-atlassian) - Interact with Atlassian Cloud products (Confluence and Jira) including searching/reading Confluence spaces/pages, accessing Jira issues, and project metadata.
 - [open-strategy-partners/osp_marketing_tools](https://github.com/open-strategy-partners/osp_marketing_tools) - Content editing codes, value map, and positioning tools for product marketing.
+- [nowork-studio/NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads (~2.9k stars). Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP for site audits, keyword research, ad audits, and wasted-spend detection.
 - [MohamedAbdallah-14/unslop](https://github.com/MohamedAbdallah-14/unslop) - MCP server and CLI that removes named AI writing tells from text: tricolons, em-dash pileups, hedging stacks, sycophancy openers, overused vocab like "delve" and "crucial". Lint-only audit mode included. Five intensity levels.
 - [zcaceres/gtasks-mcp](https://github.com/zcaceres/gtasks-mcp) - Google Tasks API Model Context Protocol Server.
 - [esignaturescom/mcp-server-esignatures](https://github.com/esignaturescom/mcp-server-esignatures) - MCP server for eSignatures (https://esignatures.com)


### PR DESCRIPTION
Thanks for maintaining this list! I'd like to add [NotFair](https://github.com/nowork-studio/NotFair), an open-source set of Claude Code agent skills for marketing work (~2.9k stars, MIT license).

NotFair covers three areas:
- **SEO & GEO** — site audits, keyword research, meta tags, schema markup, content writing, and geo optimization
- **Google Ads** — account audits, wasted-spend detection, search-term cleanup, keyword and bid management
- **Meta Ads** — Facebook/Instagram ROAS analysis, creative fatigue detection, audience overlap

It connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

I've placed it in the **Productivity** section alongside `osp_marketing_tools`, which felt like the closest match. Happy to move or trim the description if you prefer a different spot or shorter wording.