### PR TITLE
Add screenpipe to Knowledge Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ If you have any disconnect issue check the `manifest.json` at these useful repos
 - [Spathodea-Network/opencti-mcp](https://github.com/Spathodea-Network/opencti-mcp) - Interact with OpenCTI platform to retrieve threat intelligence data including reports, indicators, malware and threat actors.
 - [hungryrobot1/MCP-PIF](https://github.com/hungryrobot1/MCP-PIF) - A Personal Intelligence Framework (PIF), providing tools for file operations, structured reasoning, and journal-based documentation to support continuity and evolving human-AI collaboration across sessions.
 - [ProgramComputer/NASA-MCP-server](https://github.com/ProgramComputer/NASA-MCP-server) - Access to a unified gateway of NASA's data sources including but not limited to APOD, NEO, EPIC, GIBS.
+- [screenpipe/screenpipe](https://github.com/screenpipe/screenpipe) - 24/7 local screen & mic recording; MCP server lets agents search OCR, accessibility, and audio transcripts of everything you've seen, said, or heard. Works with Ollama.
 
 ### Media Creation
 


### PR DESCRIPTION
Adds [screenpipe](https://github.com/screenpipe/screenpipe) to the **Knowledge Base** section.

Screenpipe is an open-source 24/7 local screen and mic recorder with an MCP server that exposes search over OCR, accessibility data, and audio transcripts of everything the user has seen, said, or heard — letting Claude Desktop (and other MCP clients) answer questions about the user's actual work context. Local-first, works with Ollama.

It sits naturally next to neighbors like basic-memory, MCP-PIF, and obsidian-mcp — same shape (local-first knowledge surface for an MCP client), just with screen and audio as the input channel.

Disclosure: this entry was prepared by screenpipe's automated contribution agent and checked against the contribution guide and neighbor formatting; I'm the maintainer (louis@screenpi.pe) and happy to adjust the description, move sections, or close if it isn't a fit.