### PR TITLE
feat: add StandupCraft to Productivity — MCP server for developer standups

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ If you have any disconnect issue check the `manifest.json` at these useful repos
 - [hichana/goalstory-mcp](https://github.com/hichana/goalstory-mcp) - a Goal Tracker and Visualization Tool for personal and professional development.
 - [horizondatawave/hdw-mcp-server](https://github.com/horizondatawave/hdw-mcp-server) - Access to profile data and management of user account with [HorizonDataWave.ai](https://horizondatawave.ai/).
 - [kenjihikmatullah/productboard-mcp](https://github.com/kenjihikmatullah/productboard-mcp) - Integrate the Productboard API into agentic workflows via MCP.
+- [jabbawocky/standupcraft](https://github.com/jabbawocky/standupcraft) - MCP server that reads your git commits and GitHub activity to generate daily standups, weekly client reports, and sprint retros inside Claude Desktop. No API key required — runs entirely locally.
 
 ### Professional Apps
 


### PR DESCRIPTION
**StandupCraft** — MCP server that reads your git commits and GitHub activity to generate daily standups, weekly client reports, and sprint retros inside Claude Desktop.

- **GitHub:** https://github.com/jabbawocky/standupcraft
- **Language:** TypeScript
- **Scope:** Local-first (reads local git history; optional GitHub API for PR/review detail)
- **OS:** macOS, Windows, Linux
- **Install:** `npx -y github:jabbawocky/standupcraft`
- **Tools:** 5 — `get_git_activity`, `get_github_activity`, `generate_standup`, `generate_weekly_summary`, `list_configured_sources`
- **API key:** not required for git activity (optional GITHUB_TOKEN for GitHub events)
- **License:** MIT

Fits the **Productivity** section — for developers who spend time reconstructing yesterday's work from memory before standups or client reports.