### PR TITLE
Add BuyWhere MCP server to MCP Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ If you have any disconnect issue check the `manifest.json` at these useful repos
 - [sparfenyuk/mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) - Connect to MCP servers that run on SSE transport, or expose stdio servers as an SSE server.
 - [anaisbetts/mcp-installer](https://github.com/anaisbetts/mcp-installer) - This server is a server that installs other MCP servers for you.
 - [modelcontextprotocol/everything](https://github.com/modelcontextprotocol/servers/blob/main/src/everything) - This MCP server exercises all the features of the MCP protocol. It is a test server for builders of MCP clients.
+- [BuyWhere/buywhere-mcp](https://github.com/BuyWhere/buywhere-mcp) - Real-time product search and price-comparison MCP server for AI agents. 11M+ products across Shopee, Lazada, Amazon, Walmart, and 20+ retailers in Singapore, SEA, and US. Free API key with no signup.
 
 ### Knowledge Base
 


### PR DESCRIPTION
## Add BuyWhere MCP server to MCP Tools section

Adds BuyWhere to the **MCP Tools** section of milisp/awesome-claude-dxt, alongside unifai-mcp-server, mcp-create, mcp-compass, e2b-dev/mcp-server, modelcontextprotocol/everything, and other general-purpose MCP tool servers.

### Format
Single-line markdown bullet, matching the format of surrounding entries:
```
- [BuyWhere/buywhere-mcp](https://github.com/BuyWhere/buywhere-mcp) - <description>
```

### Why it fits
- It's an MCP server (the whole section is about MCP servers)
- Works with Claude Desktop (DXT-compatible via the stdio npx command)
- Listed on MCP Registry as `io.github.BuyWhere/buywhere-mcp@1.0.5`
- Real-time product search and price comparison across 11M+ products in SG/SEA/US

### About BuyWhere MCP
- **Coverage:** 11M+ products across Shopee, Lazada, Amazon, Walmart, and 20+ retailers in Singapore, SEA, and US
- **Tools:** `search_products`, `get_product`, `compare_products`, `find_best_price`, `get_deals`, `list_categories`, `find_similar`
- **Endpoints:** streamable-HTTP at `https://api.buywhere.ai/mcp`, stdio via `npx @buywhere/mcp-server`
- **Free API key** (no signup flow, 3-second `POST /v1/auth/register`)
- **Open source** (MIT)
- **Production traffic:** HTTP 200, weekly releases

Let me know if you'd like the description shortened or moved to a different section.