### PR TITLE
Add AgentsCoin to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ If you have any disconnect issue check the `manifest.json` at these useful repos
 - [mcpdotdirect/evm-mcp-server](https://github.com/mcpdotdirect/evm-mcp-server) - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - [marctheshark3/ergo-mcp](https://github.com/marctheshark3/ergo-mcp) - -An MCP server to integrate Ergo Blockchain Node and Explorer APIs for checking address balances, analyzing transactions, viewing transaction history, performing forensic analysis of addresses, searching for tokens, and monitoring network status.
 - [XeroAPI/xero-mcp-server](https://github.com/XeroAPI/xero-mcp-server) - This is a Model Context Protocol (MCP) server implementation for Xero. It provides a bridge between the MCP protocol and Xero's API, allowing for standardized access to Xero's accounting and business features.
+- [axiosdevs/agentscoin-claude-extension](https://github.com/axiosdevs/agentscoin-claude-extension) - Give your AI agent its own money — create a wallet, get AGENT from the faucet, send, and create/trade tokens on a live EVM chain. MCP server + one-click Claude Desktop extension.
 
 ### examples
 

--- a/servers/axiosdevs/agentscoin-claude-extension/manifest.json
+++ b/servers/axiosdevs/agentscoin-claude-extension/manifest.json
@@ -1,0 +1,91 @@
+{
+  "dxt_version": "0.1",
+  "name": "agentscoin-claude-extension",
+  "display_name": "AgentsCoin",
+  "version": "1.0.0",
+  "description": "Give your AI agent its own money — create a wallet, get AGENT from the faucet, send, and create/trade tokens on a live EVM chain. MCP server + one-click Claude Desktop extension.",
+  "long_description": "AgentsCoin gives your AI agent its own money on a live EVM chain. The agent can create a wallet, mine AGENT directly from the faucet inside the chat, check balances, send AGENT, and create and trade its own tokens (create_coin, add_liquidity, swap). Ships as both a standard MCP server (npx agentscoin-mcp, or the remote endpoint at https://agents-coin.com/mcp) and a one-click Claude Desktop extension (.mcpb).",
+  "author": {
+    "name": "axiosdevs"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/axiosdevs/agentscoin-claude-extension"
+  },
+  "homepage": "https://agents-coin.com",
+  "screenshots": [],
+  "server": {
+    "type": "node",
+    "entry_point": "",
+    "mcp_config": {
+      "command": "npx",
+      "args": [
+        "agentscoin-mcp"
+      ]
+    }
+  },
+  "tools": [
+    {
+      "name": "network_info",
+      "description": "Get information about the AgentsCoin EVM chain (chain id, RPC, current status)."
+    },
+    {
+      "name": "create_wallet",
+      "description": "Create a new wallet for the agent on the AgentsCoin chain."
+    },
+    {
+      "name": "mine",
+      "description": "Get AGENT from the faucet — works directly inside the chat."
+    },
+    {
+      "name": "balance",
+      "description": "Check the AGENT and token balances of a wallet."
+    },
+    {
+      "name": "send",
+      "description": "Send AGENT to another address."
+    },
+    {
+      "name": "create_coin",
+      "description": "Create a new token on the AgentsCoin chain."
+    },
+    {
+      "name": "add_liquidity",
+      "description": "Add liquidity for a token to enable trading."
+    },
+    {
+      "name": "swap",
+      "description": "Swap between AGENT and tokens on the chain."
+    }
+  ],
+  "prompts": [
+    {
+      "name": "Set up a wallet",
+      "description": "Create a wallet and fund it from the faucet",
+      "text": "Create a wallet for me and mine some AGENT from the faucet"
+    },
+    {
+      "name": "Check balance",
+      "description": "Check the agent's AGENT balance",
+      "text": "What is my current AGENT balance?"
+    },
+    {
+      "name": "Create a token",
+      "description": "Create a new token and add liquidity",
+      "text": "Create a token called MyCoin and add some liquidity so it can be traded"
+    }
+  ],
+  "tools_generated": false,
+  "keywords": [
+    "evm",
+    "blockchain",
+    "wallet",
+    "faucet",
+    "tokens",
+    "defi",
+    "agent",
+    "cryptocurrency",
+    "finance"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
Adds **AgentsCoin** to the `### Finance` section.

AgentsCoin gives an AI agent its own money on a live EVM chain: create a wallet, get AGENT from the faucet, send, and create/trade tokens.

- MCP server: https://github.com/axiosdevs/agentscoin-mcp (`npx agentscoin-mcp`, or remote `https://agents-coin.com/mcp`)
- One-click Claude Desktop extension (.mcpb): https://github.com/axiosdevs/agentscoin-claude-extension
- Site: https://agents-coin.com

Tools (8): `network_info`, `create_wallet`, `mine` (faucet, works in chat), `balance`, `send`, `create_coin`, `add_liquidity`, `swap`.

Changes:
- One entry added to the Finance list in `README.md`.
- `servers/axiosdevs/agentscoin-claude-extension/manifest.json` describing the extension.
